### PR TITLE
Travis testing of node v4 and v5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: node_js
+
 node_js:
   - "0.10"
+  - "4"
+  - "5"
+
+sudo: false


### PR DESCRIPTION
Pumpify works great on node v4 and v5 right now– just adjusting the CI config to verify that.  The hapi ecosystem might make use of this module, and it would be great if we had a guarantee from Travis that it's compatible on versions of node that hapi supports.  Also threw in a `sudo: false` to take advantage of Travis's newer infrastructure :).  CC @arb