### PR TITLE
add node 6 and 8 to ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ language: node_js
 node_js:
   - '10'
   - '12'
+  - '8'
+  - '6'
 
 sudo: false


### PR DESCRIPTION
Hi,
since this module works also with node 8 and 6 (tried locally) I would like to add these versions of node.js to the ci.
So, in future, if you need to drop these versions for any reason the users will be noticed.

Is this ok for you?